### PR TITLE
Add-auto-tests action

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,5 +1,5 @@
 name: Continuous Integration
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,0 +1,16 @@
+name: Continuous Integration
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.12.0
+          architecture: x64
+      - name: Install dependencies
+        run: pip install -r requirements.txt 
+      - name: Run Tests
+        run: python -m pytest


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for continuous integration. The workflow is triggered on pushes and pull requests and includes steps to set up the environment, install dependencies, and run unit tests.

Continuous Integration workflow:

* [`.github/workflows/unittests.yaml`](diffhunk://#diff-37232da2d92e889efadfe08a270c88e4b6a38098b9ca991f252086de6c201060R1-R16): Added a new workflow named "Continuous Integration" that runs on `ubuntu-latest`, sets up Python 3.12.0, installs dependencies from `requirements.txt`, and executes unit tests with `pytest`.